### PR TITLE
Fix build system: Add C++17 support and modern CMake/Conan integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,10 +113,16 @@ endif()
 # These packages are defined in conanfile.txt and installed during the build process.
 # Each find_package() call loads Conan-generated CMake modules that define targets.
 
+# Conan Integration
+# ----------------
+# Ensure CMake prioritizes Conan-generated config files over system find modules
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
+list(PREPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
 # Core Dependencies:
 find_package(GTest REQUIRED)     # GoogleTest framework for unit testing
 find_package(spdlog REQUIRED)    # High-performance logging library  
-find_package(Protobuf REQUIRED)  # Protocol buffer serialization (includes protoc compiler)
+find_package(protobuf REQUIRED)  # Protocol buffer serialization (includes protoc compiler)
 find_package(gRPC REQUIRED)      # gRPC framework for remote procedure calls
 
 # gRPC C++ Plugin Detection

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -13,5 +13,3 @@ CMakeToolchain
 gtest/*:shared=False
 spdlog/*:shared=False
 grpc/*:shared=False
-compiler.libcxx=libstdc++11
-build_type=Release

--- a/conanprofile
+++ b/conanprofile
@@ -1,0 +1,8 @@
+# Dashcam Project Conan Profile
+# This profile ensures consistent build settings across all developers
+# It inherits platform detection from default profile but enforces C++17
+
+include(default)
+
+[settings]
+compiler.cppstd=17

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -57,7 +57,7 @@ Set-Location $BuildDir
 
 # Install Conan dependencies
 Write-Host "Installing Conan dependencies..."
-& conan install $ProjectRoot --output-folder=. --build=missing --settings=build_type=$BuildType
+& conan install $ProjectRoot --output-folder=. --build=missing --profile="$ProjectRoot\conanprofile" --settings=build_type=$BuildType
 
 if ($LASTEXITCODE -ne 0) {
     Write-Host "Error: Conan install failed"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,7 +88,7 @@ cd "$BUILD_DIR"
 # Install Conan dependencies
 echo "Installing Conan dependencies..."
 uv run conan install "$PROJECT_ROOT" --output-folder=. --build=missing \
-    --settings=build_type="$BUILD_TYPE"
+    --profile="$PROJECT_ROOT/conanprofile" --settings=build_type="$BUILD_TYPE"
 
 # Configure with CMake
 echo "Configuring with CMake..."


### PR DESCRIPTION
- Add project-specific conanprofile with C++17 standard enforcement
- Update CMakeLists.txt with CMAKE_MODULE_PATH and CMAKE_PREFIX_PATH for Conan 2.0
- Modify build scripts to use project-specific Conan profile consistently
- Resolve gRPC C++17 dependency requirement vs default C++14 conflict
- Enable proper CMake package detection for all Conan dependencies (GTest, spdlog, gRPC, etc.)

This fixes the build failures caused by:
1. gRPC requiring C++17 but Conan defaulting to C++14
2. CMake not finding Conan-generated package configs
3. Inconsistent C++ standard usage across the build system

Tested: Build completes successfully with all dependencies resolved